### PR TITLE
[FEDEXSHIP-29] added grams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added grams as a unit of measurement
+
 ## [1.9.1] - 2022-05-03
 
 ### Fixed

--- a/dotnet/Services/FedExRateRequest.cs
+++ b/dotnet/Services/FedExRateRequest.cs
@@ -436,12 +436,16 @@
         }
 
         public void setWeight(Weight weight, double weightAmount) {
+            weight.Value = Convert.ToDecimal(weightAmount);
+            weight.ValueSpecified = true;
+            if (this._merchantSettings.UnitWeight.Equals("G")) {
+                this._merchantSettings.UnitWeight = "KG";
+                weight.Value /= 1000;
+            }
             WeightUnits weightUnits;
             Enum.TryParse<WeightUnits>(this._merchantSettings.UnitWeight, out weightUnits);
             weight.Units = weightUnits;
             weight.UnitsSpecified = true;
-            weight.Value = Convert.ToDecimal(weightAmount);
-            weight.ValueSpecified = true;
         }
 
         public void setDimensions(Dimensions dimensions, double length, double width, double height) {

--- a/messages/context.json
+++ b/messages/context.json
@@ -2,6 +2,7 @@
   "admin/fedex-shipping.title": "admin/fedex-shipping.title",
   "admin/fedex-shipping.isLive": "admin/fedex-shipping.isLive",
   "admin/fedex-shipping.kg": "admin/fedex-shipping.kg",
+  "admin/fedex-shipping.g": "admin/fedex-shipping.g",
   "admin/fedex-shipping.lb": "admin/fedex-shipping.lb",
   "admin/fedex-shipping.in": "admin/fedex-shipping.in",
   "admin/fedex-shipping.cm": "admin/fedex-shipping.cm",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2,6 +2,7 @@
   "admin/fedex-shipping.title": "FedEx Shipping",
   "admin/fedex-shipping.isLive": "Is Live",
   "admin/fedex-shipping.kg": "Kilograms",
+  "admin/fedex-shipping.g": "Grams",
   "admin/fedex-shipping.lb": "Pounds",
   "admin/fedex-shipping.in": "Inches",
   "admin/fedex-shipping.cm": "Centimeters",

--- a/react/components/Configurations.tsx
+++ b/react/components/Configurations.tsx
@@ -340,6 +340,9 @@ const Configurations: FC = () => {
           <option value="KG">
             {formatMessage({ id: 'admin/fedex-shipping.kg' })}
           </option>
+          <option value="G">
+            {formatMessage({ id: 'admin/fedex-shipping.g' })}
+          </option>
         </Select>
         <Select
           label={formatMessage({ id: 'admin/fedex-shipping.dimensions' })}


### PR DESCRIPTION
Users can now select grams as a unit of measurement for shipping
![image](https://user-images.githubusercontent.com/32426660/167004804-dff4d91b-263d-42f7-b794-d5df0c610526.png)
![image](https://user-images.githubusercontent.com/32426660/167004945-82e041b9-71fb-407a-8aa9-373aae7e7398.png)
