### PR TITLE
[FEDEXSHIP-28] added caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added caching for the getRates function
+
 ## [1.10.0] - 2022-05-09
 
-### Addedd
+### Added
 
 - Added a new table for surcharges and hiding SLAs
 

--- a/dotnet/Data/CachedKeys.cs
+++ b/dotnet/Data/CachedKeys.cs
@@ -21,7 +21,7 @@ namespace FedexShipping.Data
 
         public async Task RemoveCacheKey(int cacheKey)
         {
-            bool removed = this._cacheKeys.Remove(cacheKey);
+            this._cacheKeys.Remove(cacheKey);
         }
 
         public async Task<List<int>> ListExpiredKeys()

--- a/dotnet/Data/CachedKeys.cs
+++ b/dotnet/Data/CachedKeys.cs
@@ -7,24 +7,24 @@ namespace FedexShipping.Data
 {
     public class CachedKeys : ICachedKeys
     {
-        private Dictionary<int, DateTime> _cacheKeys;
+        private readonly Dictionary<int, DateTime> _cacheKeys;
 
         public CachedKeys()
         {
             this._cacheKeys = new Dictionary<int, DateTime>();
         }
 
-        public async Task AddCacheKey(int cacheKey)
+        public void AddCacheKey(int cacheKey)
         {
             this._cacheKeys.Add(cacheKey, DateTime.Now);
         }
 
-        public async Task RemoveCacheKey(int cacheKey)
+        public void RemoveCacheKey(int cacheKey)
         {
             this._cacheKeys.Remove(cacheKey);
         }
 
-        public async Task<List<int>> ListExpiredKeys()
+        public List<int> ListExpiredKeys()
         {
             Dictionary<int, DateTime> keysToRemove = this._cacheKeys.Where(k => k.Value < DateTime.Now.AddMinutes(-10)).ToDictionary(c => c.Key, c => c.Value);
 

--- a/dotnet/Data/CachedKeys.cs
+++ b/dotnet/Data/CachedKeys.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace FedexShipping.Data
+{
+    public class CachedKeys : ICachedKeys
+    {
+        private Dictionary<int, DateTime> _cacheKeys;
+
+        public CachedKeys()
+        {
+            this._cacheKeys = new Dictionary<int, DateTime>();
+        }
+
+        public async Task AddCacheKey(int cacheKey)
+        {
+            this._cacheKeys.Add(cacheKey, DateTime.Now);
+        }
+
+        public async Task RemoveCacheKey(int cacheKey)
+        {
+            bool removed = this._cacheKeys.Remove(cacheKey);
+        }
+
+        public async Task<List<int>> ListExpiredKeys()
+        {
+            Dictionary<int, DateTime> keysToRemove = this._cacheKeys.Where(k => k.Value < DateTime.Now.AddMinutes(-10)).ToDictionary(c => c.Key, c => c.Value);
+
+            return keysToRemove.Select(k => k.Key).ToList();
+        }
+    }
+}

--- a/dotnet/Data/Constants.cs
+++ b/dotnet/Data/Constants.cs
@@ -1,0 +1,15 @@
+namespace FedexShipping.Data
+{
+    public class Constants
+    {
+        public const string SETTINGS_NAME = "merchantSettings";
+        public const string SETTINGS_BUCKET = "shipping_utilities";
+        public const string HEADER_VTEX_CREDENTIAL = "X-Vtex-Credential";
+        public const string HEADER_VTEX_ACCOUNT = "X-Vtex-Account";
+        public const string HEADER_VTEX_WORKSPACE = "X-Vtex-Workspace";
+        public const string APPLICATION_JSON = "application/json";
+        public const string AUTHORIZATION_HEADER_NAME = "Authorization";
+        public const string RATES_BUCKET = "rates-response";
+        public const string VTEX_ID_HEADER_NAME = "VtexIdclientAutCookie";    
+    }
+}

--- a/dotnet/Data/Constants.cs
+++ b/dotnet/Data/Constants.cs
@@ -1,6 +1,6 @@
 namespace FedexShipping.Data
 {
-    public class Constants
+    public static class Constants
     {
         public const string SETTINGS_NAME = "merchantSettings";
         public const string SETTINGS_BUCKET = "shipping_utilities";

--- a/dotnet/Data/FedExCacheRepository.cs
+++ b/dotnet/Data/FedExCacheRepository.cs
@@ -67,14 +67,14 @@ namespace FedexShipping.Data
                 success = await CacheRatesResponse(cacheKey, fedexRatesCache);
                 if (success)
                 {
-                    await _cachedKeys.AddCacheKey(cacheKey);
+                    _cachedKeys.AddCacheKey(cacheKey);
                 }
 
-                List<int> keysToRemove = await _cachedKeys.ListExpiredKeys();
+                List<int> keysToRemove = _cachedKeys.ListExpiredKeys();
                 foreach (int cacheKeyToRemove in keysToRemove)
                 {
                     await CacheRatesResponse(cacheKey, null);
-                    await _cachedKeys.RemoveCacheKey(cacheKey);
+                    _cachedKeys.RemoveCacheKey(cacheKey);
                 }
             }
             catch (Exception ex)

--- a/dotnet/Data/FedExCacheRepository.cs
+++ b/dotnet/Data/FedExCacheRepository.cs
@@ -1,0 +1,139 @@
+namespace FedexShipping.Data
+{
+    using Microsoft.AspNetCore.Http;
+    using System;
+    using System.Text;
+    using System.Net.Http;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Vtex.Api.Context;
+    using FedexShipping.Models;
+    using FedexShipping.Services;
+
+    using Newtonsoft.Json;
+
+    public class FedExCacheRespository : IFedExCacheRepository
+    {
+        private readonly string _applicationName;
+
+        private readonly IVtexEnvironmentVariableProvider _environmentVariableProvider;
+
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IHttpClientFactory _clientFactory;
+        private readonly IIOServiceContext _context;
+        private readonly ICachedKeys _cachedKeys;
+
+        public FedExCacheRespository(IVtexEnvironmentVariableProvider environmentVariableProvider, IHttpContextAccessor httpContextAccessor, IHttpClientFactory clientFactory, IIOServiceContext context, ICachedKeys cachedKeys) {
+            this._environmentVariableProvider = environmentVariableProvider ??
+                                    throw new ArgumentNullException(nameof(environmentVariableProvider));
+
+            this._httpContextAccessor = httpContextAccessor ??
+                            throw new ArgumentNullException(nameof(httpContextAccessor));
+
+            this._clientFactory = clientFactory ??
+                                    throw new ArgumentNullException(nameof(clientFactory));
+        
+            this._context = context ??
+                               throw new ArgumentNullException(nameof(context));
+
+            this._cachedKeys = cachedKeys ??
+                               throw new ArgumentNullException(nameof(cachedKeys));
+                               
+            this._applicationName =
+                $"{this._environmentVariableProvider.ApplicationVendor}.{this._environmentVariableProvider.ApplicationName}";
+        }
+        public bool TryGetCache(int cacheKey, out GetRatesResponseWrapper fedexRatesCache)
+        {
+            bool success = false;
+            fedexRatesCache = null;
+            try
+            {
+                fedexRatesCache = GetCachedRatesResponse(cacheKey).Result;
+                success = fedexRatesCache != null;
+            }
+            catch (Exception ex)
+            {
+                _context.Vtex.Logger.Error("TryGetCache", null, "Error getting cache", ex);
+            }
+
+            return success;
+        }
+
+        public async Task<bool> SetCache(int cacheKey, GetRatesResponseWrapper fedexRatesCache) {
+            bool success = false;
+
+            try
+            {
+                success = await CacheRatesResponse(cacheKey, fedexRatesCache);
+                if (success)
+                {
+                    await _cachedKeys.AddCacheKey(cacheKey);
+                }
+
+                List<int> keysToRemove = await _cachedKeys.ListExpiredKeys();
+                foreach (int cacheKeyToRemove in keysToRemove)
+                {
+                    await CacheRatesResponse(cacheKey, null);
+                    await _cachedKeys.RemoveCacheKey(cacheKey);
+                }
+            }
+            catch (Exception ex)
+            {
+                _context.Vtex.Logger.Error("TryGetCache", null, "Error setting cache", ex);
+            }
+
+            return success;
+        }
+
+        public async Task<GetRatesResponseWrapper> GetCachedRatesResponse(int cacheKey)
+        {
+            GetRatesResponseWrapper getRatesResponseWrapper = null;
+
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get,
+                RequestUri = new Uri($"http://infra.io.vtex.com/vbase/v2/{this._httpContextAccessor.HttpContext.Request.Headers[Constants.HEADER_VTEX_ACCOUNT]}/{this._httpContextAccessor.HttpContext.Request.Headers[Constants.HEADER_VTEX_WORKSPACE]}/buckets/{this._applicationName}/{Constants.RATES_BUCKET}/files/{cacheKey}")
+            };
+
+            string authToken = this._httpContextAccessor.HttpContext.Request.Headers[Constants.HEADER_VTEX_CREDENTIAL];
+            if (authToken != null)
+            {
+                request.Headers.Add(Constants.AUTHORIZATION_HEADER_NAME, authToken);
+                request.Headers.Add(Constants.VTEX_ID_HEADER_NAME, authToken);
+            }
+
+            var client = _clientFactory.CreateClient();
+            var response = await client.SendAsync(request);
+            string responseContent = await response.Content.ReadAsStringAsync();
+            if (response.IsSuccessStatusCode)
+            {
+                getRatesResponseWrapper = JsonConvert.DeserializeObject<GetRatesResponseWrapper>(responseContent);
+            }
+
+            return getRatesResponseWrapper;
+        }
+
+        public async Task<bool> CacheRatesResponse(int cacheKey, GetRatesResponseWrapper fedexRatesCache)
+        {
+            var jsonSerializedTaxResponse = JsonConvert.SerializeObject(fedexRatesCache);
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Put,
+                RequestUri = new Uri($"http://infra.io.vtex.com/vbase/v2/{this._httpContextAccessor.HttpContext.Request.Headers[Constants.HEADER_VTEX_ACCOUNT]}/{this._httpContextAccessor.HttpContext.Request.Headers[Constants.HEADER_VTEX_WORKSPACE]}/buckets/{this._applicationName}/{Constants.RATES_BUCKET}/files/{cacheKey}"),
+                Content = new StringContent(jsonSerializedTaxResponse, Encoding.UTF8, Constants.APPLICATION_JSON)
+            };
+
+            string authToken = this._httpContextAccessor.HttpContext.Request.Headers[Constants.HEADER_VTEX_CREDENTIAL];
+            if (authToken != null)
+            {
+                request.Headers.Add(Constants.AUTHORIZATION_HEADER_NAME, authToken);
+                request.Headers.Add(Constants.VTEX_ID_HEADER_NAME, authToken);
+            }
+
+            var client = _clientFactory.CreateClient();
+            var response = await client.SendAsync(request);
+
+            return response.IsSuccessStatusCode;
+        }
+    }
+}

--- a/dotnet/Data/ICachedKeys.cs
+++ b/dotnet/Data/ICachedKeys.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+namespace FedexShipping.Data
+{
+    public interface ICachedKeys
+    {
+        Task AddCacheKey(int cacheKey);
+        Task RemoveCacheKey(int cacheKey);
+        Task<List<int>> ListExpiredKeys();
+    }
+}

--- a/dotnet/Data/ICachedKeys.cs
+++ b/dotnet/Data/ICachedKeys.cs
@@ -5,8 +5,8 @@ namespace FedexShipping.Data
 {
     public interface ICachedKeys
     {
-        Task AddCacheKey(int cacheKey);
-        Task RemoveCacheKey(int cacheKey);
-        Task<List<int>> ListExpiredKeys();
+        void AddCacheKey(int cacheKey);
+        void RemoveCacheKey(int cacheKey);
+        List<int> ListExpiredKeys();
     }
 }

--- a/dotnet/Data/IFedExCacheRepository.cs
+++ b/dotnet/Data/IFedExCacheRepository.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using FedexShipping.Models;
+
+namespace FedexShipping.Data
+{
+    public interface IFedExCacheRepository
+    {
+        bool TryGetCache(int cacheKey, out GetRatesResponseWrapper fedexRatesCache);
+        Task<bool> SetCache(int cacheKey, GetRatesResponseWrapper fedexRatesCache);
+    }
+}

--- a/dotnet/Data/MerchantSettingsRepository.cs
+++ b/dotnet/Data/MerchantSettingsRepository.cs
@@ -11,18 +11,10 @@
 
     public class MerchantSettingsRepository : IMerchantSettingsRepository
     {
-        private const string SETTINGS_NAME = "merchantSettings";
-        private const string BUCKET = "shipping_utilities";
-        public const string HEADER_VTEX_CREDENTIAL = "X-Vtex-Credential";
-        public const string HEADER_VTEX_ACCOUNT = "X-Vtex-Account";
-        public const string HEADER_VTEX_WORKSPACE = "X-Vtex-Workspace";
-        public const string APPLICATION_JSON = "application/json";
         private readonly IVtexEnvironmentVariableProvider _environmentVariableProvider;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IHttpClientFactory _clientFactory;
         private readonly string _applicationName;
-        private string AUTHORIZATION_HEADER_NAME;
-
 
         public MerchantSettingsRepository(IVtexEnvironmentVariableProvider environmentVariableProvider, IHttpContextAccessor httpContextAccessor, IHttpClientFactory clientFactory)
         {
@@ -38,23 +30,20 @@
             this._applicationName =
                 $"{this._environmentVariableProvider.ApplicationVendor}.{this._environmentVariableProvider.ApplicationName}";
 
-            AUTHORIZATION_HEADER_NAME = "Authorization";
         }
 
         public async Task<MerchantSettings> GetMerchantSettings(string carrier)
         {
-            // Load merchant settings
-            // 'http://apps.{{region}}.vtex.io/{{account}}/{{workspace}}/apps/{{appName}}/settings'
             var request = new HttpRequestMessage
             {
                 Method = HttpMethod.Get,
-                RequestUri = new Uri($"http://vbase.{this._environmentVariableProvider.Region}.vtex.io/{this._httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_ACCOUNT]}/{this._httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_WORKSPACE]}/buckets/{this._applicationName}/{BUCKET}/files/{SETTINGS_NAME}{carrier.ToUpper()}"),
+                RequestUri = new Uri($"http://vbase.{this._environmentVariableProvider.Region}.vtex.io/{this._httpContextAccessor.HttpContext.Request.Headers[Constants.HEADER_VTEX_ACCOUNT]}/{this._httpContextAccessor.HttpContext.Request.Headers[Constants.HEADER_VTEX_WORKSPACE]}/buckets/{this._applicationName}/{Constants.SETTINGS_BUCKET}/files/{Constants.SETTINGS_NAME}{carrier.ToUpper()}"),
             };
 
-            string authToken = this._httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_CREDENTIAL];
+            string authToken = this._httpContextAccessor.HttpContext.Request.Headers[Constants.HEADER_VTEX_CREDENTIAL];
             if (authToken != null)
             {
-                request.Headers.Add(AUTHORIZATION_HEADER_NAME, authToken);
+                request.Headers.Add(Constants.AUTHORIZATION_HEADER_NAME, authToken);
             }
 
             var client = _clientFactory.CreateClient();
@@ -88,7 +77,6 @@
 
         public async Task<bool> SetMerchantSettings(string carrier, MerchantSettings merchantSettings)
         {
-            Console.WriteLine(JsonConvert.SerializeObject(merchantSettings));
             if (merchantSettings == null)
             {
                 merchantSettings = new MerchantSettings();
@@ -98,14 +86,14 @@
             var request = new HttpRequestMessage
             {
                 Method = HttpMethod.Put,
-                RequestUri = new Uri($"http://vbase.{this._environmentVariableProvider.Region}.vtex.io/{this._httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_ACCOUNT]}/{this._httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_WORKSPACE]}/buckets/{this._applicationName}/{BUCKET}/files/{SETTINGS_NAME}{carrier.ToUpper()}"),
-                Content = new StringContent(jsonSerializedMerchantSettings, Encoding.UTF8, APPLICATION_JSON)
+                RequestUri = new Uri($"http://vbase.{this._environmentVariableProvider.Region}.vtex.io/{this._httpContextAccessor.HttpContext.Request.Headers[Constants.HEADER_VTEX_ACCOUNT]}/{this._httpContextAccessor.HttpContext.Request.Headers[Constants.HEADER_VTEX_WORKSPACE]}/buckets/{this._applicationName}/{Constants.SETTINGS_BUCKET}/files/{Constants.SETTINGS_NAME}{carrier.ToUpper()}"),
+                Content = new StringContent(jsonSerializedMerchantSettings, Encoding.UTF8, Constants.APPLICATION_JSON)
             };
 
-            string authToken = this._httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_CREDENTIAL];
+            string authToken = this._httpContextAccessor.HttpContext.Request.Headers[Constants.HEADER_VTEX_CREDENTIAL];
             if (authToken != null)
             {
-                request.Headers.Add(AUTHORIZATION_HEADER_NAME, authToken);
+                request.Headers.Add(Constants.AUTHORIZATION_HEADER_NAME, authToken);
             }
 
             var client = _clientFactory.CreateClient();

--- a/dotnet/Models/GetRatesResponseWrapper.cs
+++ b/dotnet/Models/GetRatesResponseWrapper.cs
@@ -1,7 +1,6 @@
 ﻿using FedExRateServiceReference;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace FedexShipping.Models
 {

--- a/dotnet/Services/FedExRateRequest.cs
+++ b/dotnet/Services/FedExRateRequest.cs
@@ -124,10 +124,6 @@
                             if (reply.HighestSeverity == NotificationSeverityType.SUCCESS || reply.HighestSeverity == NotificationSeverityType.NOTE || reply.HighestSeverity == NotificationSeverityType.WARNING)
                             {
                                 ShowRateReply(reply);
-                                int totalQuantity = 0;
-                                foreach (Item item in getRatesRequest.items) {
-                                    totalQuantity += item.quantity;
-                                }
 
                                 Dictionary<string, double> ratesRatio = CalculateRatesRatio(getRatesRequest.items);
                                 foreach(RateReplyDetail detail in reply.RateReplyDetails)
@@ -187,7 +183,10 @@
                     }
                 }
 
-                await _fedExCacheRespository.SetCache(cacheKey, getRatesResponseWrapperParent);
+                // Only cache if the response is successful
+                if (getRatesResponseWrapperParent.Success) {
+                    await _fedExCacheRespository.SetCache(cacheKey, getRatesResponseWrapperParent);
+                }
             }
             return getRatesResponseWrapperParent;
         }

--- a/dotnet/Services/FedExRateRequest.cs
+++ b/dotnet/Services/FedExRateRequest.cs
@@ -15,6 +15,7 @@
     {
         private readonly IIOServiceContext _context;
         private readonly IMerchantSettingsRepository _merchantSettingsRepository;
+        private readonly IFedExCacheRepository _fedExCacheRespository;
         private const string CARRIER = "FedEx";
         private MerchantSettings _merchantSettings;
 
@@ -36,11 +37,12 @@
             {"FIREARMS", "ORM_D"},
         };
 
-        public FedExRateRequest(IMerchantSettingsRepository merchantSettingsRepository, IIOServiceContext context)
+        public FedExRateRequest(IMerchantSettingsRepository merchantSettingsRepository, IIOServiceContext context, IFedExCacheRepository fedExCacheRepository)
         {
             this._merchantSettingsRepository = merchantSettingsRepository ??
                                             throw new ArgumentNullException(nameof(merchantSettingsRepository));
             this._context = context ?? throw new ArgumentNullException(nameof(context));
+            this._fedExCacheRespository = fedExCacheRepository ?? throw new ArgumentNullException(nameof(fedExCacheRepository));
         }
 
         public async Task<GetRatesResponseWrapper> GetRates(GetRatesRequest getRatesRequest)
@@ -48,119 +50,144 @@
             this._merchantSettings = await _merchantSettingsRepository.GetMerchantSettings(CARRIER);
             GetRatesResponseWrapper getRatesResponseWrapperParent = new GetRatesResponseWrapper();
             getRatesResponseWrapperParent.Success = true;
-            Dictionary<String, List<Item>> splitItems = SplitRequestItemsByModal(getRatesRequest);
             
-            RatePortTypeClient client;
-            if (this._merchantSettings.IsLive)
-            {
-                string remoteAddress = "https://ws.fedex.com:443/web-services";
-                client = new RatePortTypeClient(RatePortTypeClient.EndpointConfiguration.RateServicePort, remoteAddress);
+            GetRatesResponseWrapper fedexCachedResponse;
+            int cacheKey = $@"
+                {_context.Vtex.App.Version}
+                {JsonConvert.SerializeObject(this._merchantSettings)}
+                {getRatesRequest.origin.zipCode}
+                {getRatesRequest.destination.zipCode}
+                {JsonConvert.SerializeObject(getRatesRequest.items)}"
+                .GetHashCode();
+
+            if (_fedExCacheRespository.TryGetCache(cacheKey, out fedexCachedResponse)) {
+                getRatesResponseWrapperParent = fedexCachedResponse;
+                _context.Vtex.Logger.Info("GetRates", "Cache Used", 
+                    "Cached Result", 
+                    new[]
+                    {
+                        ( "entireObject", JsonConvert.SerializeObject(fedexCachedResponse)),
+                    }
+                );
             }
             else
             {
-                client = new RatePortTypeClient();
-            }
+                Dictionary<String, List<Item>> splitItems = SplitRequestItemsByModal(getRatesRequest);
+                
+                RatePortTypeClient client;
+                if (this._merchantSettings.IsLive)
+                {
+                    string remoteAddress = "https://ws.fedex.com:443/web-services";
+                    client = new RatePortTypeClient(RatePortTypeClient.EndpointConfiguration.RateServicePort, remoteAddress);
+                }
+                else
+                {
+                    client = new RatePortTypeClient();
+                }
 
-            Dictionary<string, SlaSettings> slaMapping = new Dictionary<string, SlaSettings>();
+                Dictionary<string, SlaSettings> slaMapping = new Dictionary<string, SlaSettings>();
 
-            foreach (SlaSettings slaSettings in this._merchantSettings.SlaSettings) {
-                slaMapping.Add(slaSettings.Sla, slaSettings);
-            }
+                foreach (SlaSettings slaSettings in this._merchantSettings.SlaSettings) {
+                    slaMapping.Add(slaSettings.Sla, slaSettings);
+                }
 
-            foreach (KeyValuePair<string, List<Item>> entry in splitItems) {
-                if (entry.Value.Count > 0) {
-                    GetRatesResponseWrapper getRatesResponseWrapper = new GetRatesResponseWrapper();
-                    getRatesRequest.items = entry.Value;
-                    RateRequest request = await CreateRateRequest(getRatesRequest);
+                foreach (KeyValuePair<string, List<Item>> entry in splitItems) {
+                    if (entry.Value.Count > 0) {
+                        GetRatesResponseWrapper getRatesResponseWrapper = new GetRatesResponseWrapper();
+                        getRatesRequest.items = entry.Value;
+                        RateRequest request = await CreateRateRequest(getRatesRequest);
 
-                    try
-                    {
-                        _context.Vtex.Logger.Info("GetRates", "FedEx RatesRequest", 
-                            "Mapped RequestedShipment of RateRequest To FedEx", 
-                            new[]
-                            {
-                                ( "entireObject", JsonConvert.SerializeObject(request.RequestedShipment)),
-                            }
-                        );
-                        Stopwatch stopWatch = new Stopwatch();
-                        stopWatch.Start();
-                        getRatesResponse ratesResponse = await client.getRatesAsync(request);
-                        stopWatch.Stop();
-                        TimeSpan ts = stopWatch.Elapsed;
-                        _context.Vtex.Logger.Info("GetRates", "FedEx RatesResponse Time", "Time Spent in MS",
-                            new[]
-                            {
-                                ( "timeLapsed", ts.TotalMilliseconds.ToString()),
-                            }
-                        );
-                        getRatesResponseWrapper.timeSpan = ts;
-                        RateReply reply = ratesResponse.RateReply;
-                        getRatesResponseWrapperParent.HighestSeverity.Add(reply.HighestSeverity.ToString());                
-                        if (reply.HighestSeverity == NotificationSeverityType.SUCCESS || reply.HighestSeverity == NotificationSeverityType.NOTE || reply.HighestSeverity == NotificationSeverityType.WARNING)
+                        try
                         {
-                            ShowRateReply(reply);
-                            //string replyjson = JsonConvert.SerializeObject(reply);
-                            int totalQuantity = 0;
-                            foreach (Item item in getRatesRequest.items) {
-                                totalQuantity += item.quantity;
-                            }
+                            _context.Vtex.Logger.Info("GetRates", "FedEx RatesRequest", 
+                                "Mapped RequestedShipment of RateRequest To FedEx", 
+                                new[]
+                                {
+                                    ( "entireObject", JsonConvert.SerializeObject(request.RequestedShipment)),
+                                }
+                            );
+                            Stopwatch stopWatch = new Stopwatch();
+                            stopWatch.Start();
+                            getRatesResponse ratesResponse = await client.getRatesAsync(request);
+                            stopWatch.Stop();
+                            TimeSpan ts = stopWatch.Elapsed;
+                            _context.Vtex.Logger.Info("GetRates", "FedEx RatesResponse Time", "Time Spent in MS",
+                                new[]
+                                {
+                                    ( "timeLapsed", ts.TotalMilliseconds.ToString()),
+                                }
+                            );
 
-                            Dictionary<string, double> ratesRatio = CalculateRatesRatio(getRatesRequest.items);
-                            foreach(RateReplyDetail detail in reply.RateReplyDetails)
+                            getRatesResponseWrapper.timeSpan = ts;
+                            RateReply reply = ratesResponse.RateReply;
+                            getRatesResponseWrapperParent.HighestSeverity.Add(reply.HighestSeverity.ToString());
+                            if (reply.HighestSeverity == NotificationSeverityType.SUCCESS || reply.HighestSeverity == NotificationSeverityType.NOTE || reply.HighestSeverity == NotificationSeverityType.WARNING)
                             {
-                                if (!slaMapping[detail.ServiceDescription.Description].Hidden) {
-                                    TimeSpan transitArrival = detail.DeliveryTimestamp - getRatesRequest.shippingDateUTC;
-                                    string transitString = new TimeSpan(transitArrival.Days, transitArrival.Hours, transitArrival.Minutes, transitArrival.Seconds).ToString();
-                                    foreach (Item item in getRatesRequest.items) {
-                                        GetRatesResponse rateResponse = new GetRatesResponse
-                                        {
-                                            carrierId = "FEDEX",
-                                            itemId = item.id,
-                                            price = detail.RatedShipmentDetails[0].ShipmentRateDetail.TotalNetCharge.Amount * Convert.ToDecimal(ratesRatio[item.id]),
-                                            numberOfPackages = item.quantity,
-                                            estimateDate = detail.DeliveryTimestamp,
-                                            shippingMethod = detail.ServiceDescription.Description,
-                                            transitTime = transitString,
-                                            carrierSchedule = new List<Schedule>(),
-                                            deliveryChannel = "delivery",
-                                            weekendAndHolidays = new WeekendAndHolidays(),
-                                            pickupAddress = null,
-                                        };
+                                ShowRateReply(reply);
+                                int totalQuantity = 0;
+                                foreach (Item item in getRatesRequest.items) {
+                                    totalQuantity += item.quantity;
+                                }
 
-                                        rateResponse.price += Convert.ToDecimal(slaMapping[rateResponse.shippingMethod].SurchargePercent / 100) * rateResponse.price + Convert.ToDecimal(slaMapping[rateResponse.shippingMethod].SurchargeFlatRate);
+                                Dictionary<string, double> ratesRatio = CalculateRatesRatio(getRatesRequest.items);
+                                foreach(RateReplyDetail detail in reply.RateReplyDetails)
+                                {
+                                    if (!slaMapping[detail.ServiceDescription.Description].Hidden) {
+                                        TimeSpan transitArrival = detail.DeliveryTimestamp - getRatesRequest.shippingDateUTC;
+                                        string transitString = new TimeSpan(transitArrival.Days, transitArrival.Hours, transitArrival.Minutes, transitArrival.Seconds).ToString();
+                                        foreach (Item item in getRatesRequest.items) {
+                                            GetRatesResponse rateResponse = new GetRatesResponse
+                                            {
+                                                carrierId = "FEDEX",
+                                                itemId = item.id,
+                                                price = detail.RatedShipmentDetails[0].ShipmentRateDetail.TotalNetCharge.Amount * Convert.ToDecimal(ratesRatio[item.id]),
+                                                numberOfPackages = item.quantity,
+                                                estimateDate = detail.DeliveryTimestamp,
+                                                shippingMethod = detail.ServiceDescription.Description,
+                                                transitTime = transitString,
+                                                carrierSchedule = new List<Schedule>(),
+                                                deliveryChannel = "delivery",
+                                                weekendAndHolidays = new WeekendAndHolidays(),
+                                                pickupAddress = null,
+                                            };
 
-                                        rateResponse.carrierBusinessHours = new BusinessHour[7];
-                                        for (int day = 0; day < 7; day++) {
-                                            rateResponse.carrierBusinessHours[day] = new BusinessHour((DayOfWeek) day, new TimeSpan(0, 0, 0).ToString(), new TimeSpan(23, 59, 59).ToString());
+                                            rateResponse.price += Convert.ToDecimal(slaMapping[rateResponse.shippingMethod].SurchargePercent / 100) * rateResponse.price + Convert.ToDecimal(slaMapping[rateResponse.shippingMethod].SurchargeFlatRate);
+
+                                            rateResponse.carrierBusinessHours = new BusinessHour[7];
+                                            for (int day = 0; day < 7; day++) {
+                                                rateResponse.carrierBusinessHours[day] = new BusinessHour((DayOfWeek) day, new TimeSpan(0, 0, 0).ToString(), new TimeSpan(23, 59, 59).ToString());
+                                            }
+
+                                            getRatesResponseWrapper.GetRatesResponses.Add(rateResponse);
                                         }
-
-                                        getRatesResponseWrapper.GetRatesResponses.Add(rateResponse);
                                     }
                                 }
+
+                                getRatesResponseWrapper.Success = true;
                             }
 
-                            getRatesResponseWrapper.Success = true;
+                            ShowNotifications(reply);
+                            foreach(Notification notification in reply.Notifications)
+                            {
+                                getRatesResponseWrapper.Notifications.Add(notification);
+                            }
                         }
-
-                        ShowNotifications(reply);
-                        foreach(Notification notification in reply.Notifications)
+                        catch (Exception e)
                         {
-                            getRatesResponseWrapper.Notifications.Add(notification);
+                            Console.WriteLine($"Exception: {e.Message}");
+                            Console.WriteLine($"Exception: {e.InnerException}");
+                            Console.WriteLine($"Exception: {e.StackTrace}");
+                            getRatesResponseWrapperParent.Error.Add(e.Message);
                         }
-                    }
-                    catch (Exception e)
-                    {
-                        Console.WriteLine($"Exception: {e.Message}");
-                        Console.WriteLine($"Exception: {e.InnerException}");
-                        Console.WriteLine($"Exception: {e.StackTrace}");
-                        getRatesResponseWrapperParent.Error.Add(e.Message);
-                    }
 
-                    getRatesResponseWrapperParent.GetRatesResponses.AddRange(getRatesResponseWrapper.GetRatesResponses);
-                    getRatesResponseWrapperParent.Notifications.AddRange(getRatesResponseWrapper.Notifications);
-                    getRatesResponseWrapperParent.timeSpan = getRatesResponseWrapper.timeSpan;
-                    getRatesResponseWrapperParent.Success = getRatesResponseWrapperParent.Success && getRatesResponseWrapper.Success;
+                        getRatesResponseWrapperParent.GetRatesResponses.AddRange(getRatesResponseWrapper.GetRatesResponses);
+                        getRatesResponseWrapperParent.Notifications.AddRange(getRatesResponseWrapper.Notifications);
+                        getRatesResponseWrapperParent.timeSpan = getRatesResponseWrapper.timeSpan;
+                        getRatesResponseWrapperParent.Success = getRatesResponseWrapperParent.Success && getRatesResponseWrapper.Success;
+                    }
                 }
+
+                await _fedExCacheRespository.SetCache(cacheKey, getRatesResponseWrapperParent);
             }
             return getRatesResponseWrapperParent;
         }

--- a/dotnet/StartupExtender.cs
+++ b/dotnet/StartupExtender.cs
@@ -19,9 +19,12 @@ namespace Vtex
             services.AddTransient<IFedExRateRequest, FedExRateRequest>();
             services.AddTransient<IFedExAvailabilityRequest, FedExAvailabilityRequest>();
             services.AddTransient<IFedExTrackRequest, FedExTrackRequest>();
+            services.AddTransient<IFedExEstimateDeliveryRequest, FedExEstimateDeliveryRequest>();
+            services.AddTransient<IFedExCacheRepository, FedExCacheRespository>();
+            
             services.AddSingleton<IVtexEnvironmentVariableProvider, VtexEnvironmentVariableProvider>();
             services.AddSingleton<IMerchantSettingsRepository, MerchantSettingsRepository>();
-            services.AddTransient<IFedExEstimateDeliveryRequest, FedExEstimateDeliveryRequest>();
+            services.AddSingleton<ICachedKeys, CachedKeys>();
             services.AddHttpContextAccessor();
             services.AddHttpClient();
         }

--- a/messages/context.json
+++ b/messages/context.json
@@ -15,7 +15,6 @@
   "admin/fedex-shipping.credKey": "admin/fedex-shipping.credKey",
   "admin/fedex-shipping.credPwd": "admin/fedex-shipping.credPwd",
   "admin/fedex-shipping.unitsMeasurement": "admin/fedex-shipping.unitsMeasurement",
-  "admin/fedex-shipping.hiddenSLA": "admin/fedex-shipping.hiddenSLA",
   "admin/fedex-shipping.modalMap": "admin/fedex-shipping.modalMap",
   "admin/fedex-shipping.modalMap.description": "admin/fedex-shipping.modalMap.description",
   "admin/fedex-shipping.modalTableHeader": "admin/fedex-shipping.modalTableHeader",


### PR DESCRIPTION
Changes
- Added caching for getRates

How to test
- [Try the simulator](https://fedex--sandboxusdev.myvtex.com/admin/logistics/?simulationData=%7B%22location%22%3A%7B%22zipCode%22%3A%2210003%22%2C%22country%22%3A%22USA%22%2C%22point%22%3A%5B%5D%7D%2C%22saleschannel%22%3A1%2C%22items%22%3A%5B%7B%22idSku%22%3A%22880090%22%2C%22price%22%3Anull%2C%22quantidade%22%3A1%7D%5D%7D#/freight-simulation)
- The first request should take a bit, but every subsequent request should be a lot faster.
- Use `index=io_3p_logs account=sandboxusdev app=vtexus.fedex-shipping* timeLapsed "GetRates Time"` to check time spent on splunk