### PR TITLE
[HOTFIX] weight gram conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug with unit conversion and grams
+
 ## [1.14.0] - 2022-05-20
 
 ### Added

--- a/dotnet/Services/FedExRateRequest.cs
+++ b/dotnet/Services/FedExRateRequest.cs
@@ -382,7 +382,6 @@
                     request.RequestedShipment.RequestedPackageLineItems[cnt].GroupPackageCount = getRatesRequest.items[cnt].quantity.ToString();
                     request.RequestedShipment.RequestedPackageLineItems[cnt].Weight = new Weight();
                     setWeight(request.RequestedShipment.RequestedPackageLineItems[cnt].Weight, getRatesRequest.items[cnt].unitDimension.weight);
-
                     request.RequestedShipment.RequestedPackageLineItems[cnt].Dimensions = new Dimensions();
                     setDimensions(request.RequestedShipment.RequestedPackageLineItems[cnt].Dimensions, getRatesRequest.items[cnt].unitDimension.length, getRatesRequest.items[cnt].unitDimension.width, getRatesRequest.items[cnt].unitDimension.height);
                     setDimensionUnits(request.RequestedShipment.RequestedPackageLineItems[cnt].Dimensions);

--- a/dotnet/Services/FedExRateRequest.cs
+++ b/dotnet/Services/FedExRateRequest.cs
@@ -98,7 +98,6 @@
                         GetRatesResponseWrapper getRatesResponseWrapper = new GetRatesResponseWrapper();
                         getRatesRequest.items = entry.Value;
                         RateRequest request = await CreateRateRequest(getRatesRequest);
-
                         try
                         {
                             _context.Vtex.Logger.Info("GetRates", "FedEx RatesRequest", 
@@ -401,12 +400,13 @@
         public void setWeight(Weight weight, double weightAmount) {
             weight.Value = Convert.ToDecimal(weightAmount);
             weight.ValueSpecified = true;
-            if (this._merchantSettings.UnitWeight.Equals("G")) {
-                this._merchantSettings.UnitWeight = "KG";
+            string parseUnit = this._merchantSettings.UnitWeight;
+            if (parseUnit.Equals("G")) {
+                parseUnit = "KG";
                 weight.Value /= 1000;
             }
             WeightUnits weightUnits;
-            Enum.TryParse<WeightUnits>(this._merchantSettings.UnitWeight, out weightUnits);
+            Enum.TryParse<WeightUnits>(parseUnit, out weightUnits);
             weight.Units = weightUnits;
             weight.UnitsSpecified = true;
         }
@@ -438,6 +438,7 @@
         private void ShowRateReply(RateReply reply)
         {
             Console.WriteLine("--- RateReply details ---");
+            Console.WriteLine(JsonConvert.SerializeObject(reply));
             for (int i = 0; i < reply.RateReplyDetails.Length; i++)
             {
                 RateReplyDetail rateReplyDetail = reply.RateReplyDetails[i];


### PR DESCRIPTION
Weight gram was incorrectly divided before, causing units to change for the second elem but not weight