### PR TITLE
[FEDEXSHIP-39] Binary Search for cache invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug where cache was never saving
+
+### Added
+
+- Redid caching
+- Improved Cache invalidation strategy to O(log(N))
+
 ## [1.18.1] - 2022-07-29
 
 ### Addeed

--- a/dotnet/Data/CachedKeys.cs
+++ b/dotnet/Data/CachedKeys.cs
@@ -18,17 +18,17 @@ namespace FedexShipping.Data
             this._orderedCacheKeys.Add(cacheKey, DateTime.Now);
         }
 
-        public void RemoveCacheKey(int cacheKey)
+        public void RemoveCacheKey(int index)
         {
             // Removes element at index
-            this._orderedCacheKeys.RemoveAt(cacheKey);
+            this._orderedCacheKeys.RemoveAt(index);
         }
 
         // Example: [1,2,5,9,10,11,23,44,68,90] and if the lookup is 50
         // Then all elements from index 0 to 7 will be removed
         public int ListExpiredKeys()
         {
-            int removalIndex = BinarySearch(_orderedCacheKeys, DateTime.Now.AddMinutes(-10));
+            int removalIndex = this.BinarySearch(DateTime.Now.AddMinutes(-10));
             return removalIndex;
         }
 
@@ -39,17 +39,17 @@ namespace FedexShipping.Data
 
         // Binary searches the list to find the maximum element
         // Which is less than or equal to the searching element
-        public int BinarySearch(OrderedDictionary orderedDictionary, DateTime searchTime)
+        public int BinarySearch(DateTime searchTime)
         {
             int left = 0;
-            int right = orderedDictionary.Count - 1;
+            int right = this._orderedCacheKeys.Count - 1;
             
             while (left <= right) {
                 int mid = left + ((right - left) / 2);
                 
-                if ((DateTime) orderedDictionary[mid] == searchTime) {
+                if ((DateTime) this._orderedCacheKeys[mid] == searchTime) {
                     return mid;
-                } else if ((DateTime) orderedDictionary[mid] < searchTime) {
+                } else if ((DateTime) this._orderedCacheKeys[mid] < searchTime) {
                     left = mid + 1;
                 } else {
                     right = mid - 1;

--- a/dotnet/Data/CachedKeys.cs
+++ b/dotnet/Data/CachedKeys.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Specialized;
 
 namespace FedexShipping.Data
 {
@@ -8,19 +9,25 @@ namespace FedexShipping.Data
     {
         private readonly Dictionary<int, DateTime> _cacheKeys;
 
+        // k,v as cacheKey: int, currentTime: DateTime
+        private readonly OrderedDictionary _orderedCacheKeys;
+
         public CachedKeys()
         {
             this._cacheKeys = new Dictionary<int, DateTime>();
+            this._orderedCacheKeys = new OrderedDictionary();
         }
 
         public void AddCacheKey(int cacheKey)
         {
             this._cacheKeys.Add(cacheKey, DateTime.Now);
+            this._orderedCacheKeys.Add(cacheKey, DateTime.Now);
         }
 
         public void RemoveCacheKey(int cacheKey)
         {
             this._cacheKeys.Remove(cacheKey);
+            this._orderedCacheKeys.Remove(cacheKey);
         }
 
         public List<int> ListExpiredKeys()
@@ -29,5 +36,72 @@ namespace FedexShipping.Data
 
             return keysToRemove.Select(k => k.Key).ToList();
         }
+
+        private int BinarySearch(OrderedDictionary orderedDictionary, DateTime searchTime) {
+            int left = 0;
+            int right = orderedDictionary.Count - 1;
+            
+            while (left <= right) {
+                int mid = left + (right - left) / 2;
+                
+                if ((DateTime) orderedDictionary[mid] == searchTime) {
+                    return mid;
+                } else if ((DateTime) orderedDictionary[mid] < searchTime) {
+                    left = mid + 1;
+                } else {
+                    right = mid - 1;
+                }
+            }
+            
+            return -1;
+                
+        }
     }
 }
+
+
+/*
+
+using System;
+using System.Threading;
+
+using System.Collections.Specialized;
+public class HelloWorld
+{
+    public static void Main(string[] args)
+    {
+        OrderedDictionary myDict = new OrderedDictionary();
+  
+        // Adding key and value in myDict
+        myDict.Add("key0", DateTime.Now);
+        myDict.Add("key1", DateTime.Now);
+        myDict.Add("key2", DateTime.Now);
+        myDict.Add("key3", DateTime.Now);
+        DateTime x = DateTime.Now;
+        myDict.Add("key4", x);
+        myDict.Add("key5", DateTime.Now);
+        int ans = BinarySearch(myDict, x);
+        Console.WriteLine(ans);
+    }
+    
+    public static int BinarySearch(OrderedDictionary orderedDictionary, DateTime searchTime) {
+            int left = 0;
+            int right = orderedDictionary.Count - 1;
+            
+            while (left <= right) {
+                int mid = left + (right - left) / 2;
+                
+                if ((DateTime) orderedDictionary[mid] == searchTime) {
+                    Console.WriteLine(searchTime);
+                    return mid;
+                } else if ((DateTime) orderedDictionary[mid] < searchTime) {
+                    left = mid + 1;
+                } else {
+                    right = mid - 1;
+                }
+            }
+            
+            return -1;
+        }
+}
+*/

--- a/dotnet/Data/CachedKeys.cs
+++ b/dotnet/Data/CachedKeys.cs
@@ -1,48 +1,51 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Collections.Specialized;
 
 namespace FedexShipping.Data
 {
     public class CachedKeys : ICachedKeys
     {
-        private readonly Dictionary<int, DateTime> _cacheKeys;
-
         // k,v as cacheKey: int, currentTime: DateTime
         private readonly OrderedDictionary _orderedCacheKeys;
 
         public CachedKeys()
         {
-            this._cacheKeys = new Dictionary<int, DateTime>();
             this._orderedCacheKeys = new OrderedDictionary();
         }
 
         public void AddCacheKey(int cacheKey)
         {
-            this._cacheKeys.Add(cacheKey, DateTime.Now);
             this._orderedCacheKeys.Add(cacheKey, DateTime.Now);
         }
 
         public void RemoveCacheKey(int cacheKey)
         {
-            this._cacheKeys.Remove(cacheKey);
-            this._orderedCacheKeys.Remove(cacheKey);
+            // Removes element at index
+            this._orderedCacheKeys.RemoveAt(cacheKey);
         }
 
-        public List<int> ListExpiredKeys()
+        // Example: [1,2,5,9,10,11,23,44,68,90] and if the lookup is 50
+        // Then all elements from index 0 to 7 will be removed
+        public int ListExpiredKeys()
         {
-            Dictionary<int, DateTime> keysToRemove = this._cacheKeys.Where(k => k.Value < DateTime.Now.AddMinutes(-10)).ToDictionary(c => c.Key, c => c.Value);
-
-            return keysToRemove.Select(k => k.Key).ToList();
+            int removalIndex = BinarySearch(_orderedCacheKeys, DateTime.Now.AddMinutes(-10));
+            return removalIndex;
         }
 
-        private int BinarySearch(OrderedDictionary orderedDictionary, DateTime searchTime) {
+        public OrderedDictionary GetOrderedDictionary()
+        {
+            return _orderedCacheKeys;
+        }
+
+        // Binary searches the list to find the maximum element
+        // Which is less than or equal to the searching element
+        public int BinarySearch(OrderedDictionary orderedDictionary, DateTime searchTime)
+        {
             int left = 0;
             int right = orderedDictionary.Count - 1;
             
             while (left <= right) {
-                int mid = left + (right - left) / 2;
+                int mid = left + ((right - left) / 2);
                 
                 if ((DateTime) orderedDictionary[mid] == searchTime) {
                     return mid;
@@ -53,55 +56,10 @@ namespace FedexShipping.Data
                 }
             }
             
-            return -1;
+            // If there is no match, returns 1 index
+            // behind start of final pivot between
+            return left - 1;
                 
         }
     }
 }
-
-
-/*
-
-using System;
-using System.Threading;
-
-using System.Collections.Specialized;
-public class HelloWorld
-{
-    public static void Main(string[] args)
-    {
-        OrderedDictionary myDict = new OrderedDictionary();
-  
-        // Adding key and value in myDict
-        myDict.Add("key0", DateTime.Now);
-        myDict.Add("key1", DateTime.Now);
-        myDict.Add("key2", DateTime.Now);
-        myDict.Add("key3", DateTime.Now);
-        DateTime x = DateTime.Now;
-        myDict.Add("key4", x);
-        myDict.Add("key5", DateTime.Now);
-        int ans = BinarySearch(myDict, x);
-        Console.WriteLine(ans);
-    }
-    
-    public static int BinarySearch(OrderedDictionary orderedDictionary, DateTime searchTime) {
-            int left = 0;
-            int right = orderedDictionary.Count - 1;
-            
-            while (left <= right) {
-                int mid = left + (right - left) / 2;
-                
-                if ((DateTime) orderedDictionary[mid] == searchTime) {
-                    Console.WriteLine(searchTime);
-                    return mid;
-                } else if ((DateTime) orderedDictionary[mid] < searchTime) {
-                    left = mid + 1;
-                } else {
-                    right = mid - 1;
-                }
-            }
-            
-            return -1;
-        }
-}
-*/

--- a/dotnet/Data/ICachedKeys.cs
+++ b/dotnet/Data/ICachedKeys.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Collections.Specialized;
+using System;
 
 namespace FedexShipping.Data
 {
@@ -7,5 +9,6 @@ namespace FedexShipping.Data
         void AddCacheKey(int cacheKey);
         void RemoveCacheKey(int cacheKey);
         List<int> ListExpiredKeys();
+        int BinarySearch(OrderedDictionary orderedDictionary, DateTime currentTime);
     }
 }

--- a/dotnet/Data/ICachedKeys.cs
+++ b/dotnet/Data/ICachedKeys.cs
@@ -9,6 +9,6 @@ namespace FedexShipping.Data
         void RemoveCacheKey(int cacheKey);
         int ListExpiredKeys();
         OrderedDictionary GetOrderedDictionary();
-        int BinarySearch(OrderedDictionary orderedDictionary, DateTime currentTime);
+        int BinarySearch(DateTime currentTime);
     }
 }

--- a/dotnet/Data/ICachedKeys.cs
+++ b/dotnet/Data/ICachedKeys.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System;
 
@@ -8,7 +7,8 @@ namespace FedexShipping.Data
     {
         void AddCacheKey(int cacheKey);
         void RemoveCacheKey(int cacheKey);
-        List<int> ListExpiredKeys();
+        int ListExpiredKeys();
+        OrderedDictionary GetOrderedDictionary();
         int BinarySearch(OrderedDictionary orderedDictionary, DateTime currentTime);
     }
 }

--- a/dotnet/Services/FedExRateRequest.cs
+++ b/dotnet/Services/FedExRateRequest.cs
@@ -221,7 +221,7 @@
                         cell.GetRatesResponses.AddRange(getRatesResponseWrapper.GetRatesResponses);
                         cell.Notifications.AddRange(getRatesResponseWrapper.Notifications);
                         cell.timeSpan = getRatesResponseWrapper.timeSpan;
-                        cell.Success = cell.Success && getRatesResponseWrapper.Success;
+                        cell.Success = getRatesResponseWrapper.Success;
 
                         bag.Add(cell);
                     }


### PR DESCRIPTION
This is a performance improvement for cache invalidation
Cache invalidation operations used to run on O(N) time. It now runs on O(log(N)) time.

Use the following to test caching
```json
curl --location --request POST 'https://app.io.vtex.com/vtexus.fedex-shipping/v1/sandboxusdev/fedex/shp-rates/calculate' \
--header 'VtexIdclientAutCookie: VTEXCOOKIEHERE' \
--header 'Content-Type: application/json' \
--data-raw '{
    "items": [
        {
            "id": "8",
            "quantity": 4,
            "groupId": null,
            "unitPrice": 500.0,
            "modal": "",
            "unitDimension": {
                "weight": 10.00,
                "height": 10,
                "width": 12,
                "length": 10
            }
        },
        {
            "id": "4",
            "quantity": 1,
            "groupId": null,
            "unitPrice": 2.0,
            "modal": "ELECTRONICS",
            "unitDimension": {
                "weight": 10.00,
                "height": 11,
                "width": 10,
                "length": 10
            }
        }
    ],
    "origin": {
        "zipCode": "33020",
        "country": "USA",
        "state": "FL",
        "city": "Hollywood",
        "coordinates": null,
        "residential": false
    },
    "destination": {
        "zipCode": "00010004",
        "country": "USA",
        "state": "NY",
        "city": "New York",
        "coordinates": null,
        "residential": false
    },
    "shippingDateUTC": "2022-05-31T01:02:45.128577+00:00",
    "currency": null
}'
```