### PR TITLE
FEDEXSHIP-44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- (FEDEXSHIP-44) Changed transit time calculation to use current date instead of ship date
 - GitHub reusable workflow and Cy-Runner updated to version 2
 
 ## [1.19.0] - 2022-10-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Changed
-
 - (FEDEXSHIP-44) Changed transit time calculation to use current date instead of ship date
+
+### Changed
 - GitHub reusable workflow and Cy-Runner updated to version 2
 
 ## [1.19.0] - 2022-10-11

--- a/dotnet/Services/FedExRateRequest.cs
+++ b/dotnet/Services/FedExRateRequest.cs
@@ -225,7 +225,7 @@
                                         {
                                             if (!slaMapping[detail.ServiceDescription.Description].Hidden && detail.DeliveryTimestampSpecified)
                                             {
-                                                TimeSpan transitArrival = detail.DeliveryTimestamp - getRatesRequest.shippingDateUTC;
+                                                TimeSpan transitArrival = detail.DeliveryTimestamp - DateTime.Now.ToUniversalTime();
                                                 string transitString = new TimeSpan(transitArrival.Days, transitArrival.Hours, transitArrival.Minutes, transitArrival.Seconds).ToString();
 
                                                 foreach (Item item in copyItemResult)


### PR DESCRIPTION
Changed transit time calculation to use current date instead of ship date
Previously the estimated delivery date did not reflect warehouse lead time